### PR TITLE
Add a subcommand per deployment platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,61 @@
-# dekorate-cli
-A command line tool for using dekorate without adding it to your project
+# Dekorate CLI
+
+Dekorate as a Command Line tool.
+
+# Overview
+Decorate CLI is a native binary through which you can generate Kubernetes manifests for your application.
+It's written in Java, but compiled as a native binary by leveraging the Quarkus framework. It can be used
+for Java and non-Java application.
+
+# Features
+  - Generate resources
+  - Modify existing resources
+  
+  
+# Known issues
+This tool requires `quarkus-picocli` which is not yet releashed.
+So, at the moment is not possible to build a native binary (it's only possible using quarkus snapshot builds).
+  
+# Building and installing
+
+The easiest apprroach to creating a native binary is:
+
+```
+./mvnw package -Pnative -Dquarkus.native.container-build=true
+```
+
+The command above will generate `/target/dekorate-cli-1.0-SNAPSHOT-runner`.
+You can copy the generated binary to your `$PATH`. For example:
+
+```
+cp `/target/dekorate-cli-1.0-SNAPSHOT-runner $HOME/bin/dekorate`
+```
+
+The rest of this document will assume that the tool is available in the `$PATH` as `dekorate`.
+
+
+# Usage
+
+## Generating Kubernetes manifests
+
+```
+dekorate kubernetes
+```
+
+## Generating Openshift manifests
+
+```
+dekorate openshfit
+```
+
+## Generating Knative manifests
+
+```
+dekorate knative
+```
+
+## Generating Tekton manifests
+
+```
+dekorate tekton
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dekorate</groupId>
   <artifactId>dekorate-cli</artifactId>
@@ -18,7 +18,8 @@
     <quarkus.platform.version>1.4.2.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
 
-    <dekorate.version>0.12.1</dekorate.version>
+    <dekorate.version>0.12.2</dekorate.version>
+    <picocli.version>4.3.2</picocli.version>
   </properties>
 
   <dependencyManagement>
@@ -33,14 +34,40 @@
     </dependencies>
   </dependencyManagement>
   <dependencies>
+
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
+      <version>${picocli.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>io.dekorate</groupId>
       <artifactId>kubernetes-annotations</artifactId>
       <version>${dekorate.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>openshift-annotations</artifactId>
+      <version>${dekorate.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>knative-annotations</artifactId>
+      <version>${dekorate.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>tekton-annotations</artifactId>
+      <version>${dekorate.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy</artifactId>
+      <artifactId>quarkus-arc</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/src/main/java/io/dekorate/cli/DekorateCmd.java
+++ b/src/main/java/io/dekorate/cli/DekorateCmd.java
@@ -1,0 +1,12 @@
+
+package io.dekorate.cli;
+
+import picocli.CommandLine.Command;
+
+@Command
+public class DekorateCmd implements Runnable {
+  
+  public void run() {
+  }
+
+}

--- a/src/main/java/io/dekorate/cli/Generator.java
+++ b/src/main/java/io/dekorate/cli/Generator.java
@@ -1,0 +1,44 @@
+
+package io.dekorate.cli;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import io.dekorate.Session;
+import io.dekorate.SessionReader;
+import io.dekorate.SessionWriter;
+import io.dekorate.processor.SimpleFileReader;
+import io.dekorate.processor.SimpleFileWriter;
+import io.dekorate.project.FileProjectFactory;
+import io.dekorate.project.Project;
+
+public class Generator {
+
+  private static final String DOT = ".";
+  private static final String DOT_DEKORATE = ".dekorate";
+  private static final String KUBERNETES = "kubernetes";
+  private static final String SRC = "src";
+  private static final String MAIN = "main";
+  private static final String RESOURCES = "resources";
+
+  public static void generate(String... platforms)  {
+    Set<String> targets = new HashSet<>(Arrays.asList(platforms));
+
+    Project project = new FileProjectFactory().create(new File(DOT));
+
+    final SessionWriter sessionWriter = new SimpleFileWriter(
+        project.getBuildInfo().getClassOutputDir().getParent().resolve(DOT_DEKORATE),
+        project.getBuildInfo().getClassOutputDir().getParent().resolve(KUBERNETES), true, targets);
+
+    final SessionReader sessionReader = new SimpleFileReader(project.getRoot().resolve(SRC).resolve(MAIN).resolve(KUBERNETES), targets);
+    sessionWriter.setProject(project);
+
+    final Session session = Session.getSession();
+    session.setWriter(sessionWriter);
+    session.setReader(sessionReader);
+    session.close();
+ 
+  } 
+}

--- a/src/main/java/io/dekorate/cli/KnativeCmd.java
+++ b/src/main/java/io/dekorate/cli/KnativeCmd.java
@@ -1,0 +1,12 @@
+package io.dekorate.cli;
+
+import picocli.CommandLine.Command;
+
+@Command(name = "knative", mixinStandardHelpOptions = true, version = "0.1", description = "Generates Knative manifests.")
+public class KnativeCmd implements Runnable {
+
+  @Override
+  public void run() {
+    Generator.generate("knative");
+  }
+}

--- a/src/main/java/io/dekorate/cli/KubernetesCmd.java
+++ b/src/main/java/io/dekorate/cli/KubernetesCmd.java
@@ -1,0 +1,13 @@
+package io.dekorate.cli;
+
+import picocli.CommandLine.Command;
+
+@Command(name = "kubernetes", mixinStandardHelpOptions = true, version = "0.1", description = "Generates Kubernetes manifests.")
+public class KubernetesCmd implements Runnable {
+
+  @Override
+  public void run() {
+    Generator.generate("kubernetes");
+  }
+
+}

--- a/src/main/java/io/dekorate/cli/Main.java
+++ b/src/main/java/io/dekorate/cli/Main.java
@@ -1,34 +1,21 @@
 package io.dekorate.cli;
 
-import java.io.File;
-import java.util.HashSet;
-import java.util.Set;
-
-import io.dekorate.Session;
-import io.dekorate.SessionReader;
-import io.dekorate.SessionWriter;
-import io.dekorate.processor.SimpleFileReader;
-import io.dekorate.processor.SimpleFileWriter;
-import io.dekorate.project.FileProjectFactory;
-import io.dekorate.project.Project;
 import io.quarkus.runtime.QuarkusApplication;
 import io.quarkus.runtime.annotations.QuarkusMain;
+import picocli.CommandLine;
+import picocli.CommandLine.RunAll;
 
 @QuarkusMain
 public class Main implements QuarkusApplication {
 
   public int run(String... args) throws Exception {
-    Set<String> targets = new HashSet<>();
-    targets.add("kubernetes");
-    Project project = new FileProjectFactory().create(new File("."));
-    final SessionWriter sessionWriter = new SimpleFileWriter(project.getBuildInfo().getClassOutputDir().getParent().resolve("kubernetes"), true);
-    final SessionReader sessionReader = new SimpleFileReader(project.getRoot().resolve("src").resolve("main").resolve("kubernetes"), targets);
-    sessionWriter.setProject(project);
-    final Session session = Session.getSession();
-    session.setWriter(sessionWriter);
-    session.setReader(sessionReader);
-    session.close();
-    return 1;
+    CommandLine cmd = new CommandLine(new DekorateCmd())
+      .addSubcommand(new KubernetesCmd())
+      .addSubcommand(new KnativeCmd())
+      .addSubcommand(new TektonCmd())
+      .addSubcommand(new OpenshiftCmd());
+
+    cmd.setExecutionStrategy(new RunAll());
+    return cmd.execute(args);
   }
 }
-

--- a/src/main/java/io/dekorate/cli/OpenshiftCmd.java
+++ b/src/main/java/io/dekorate/cli/OpenshiftCmd.java
@@ -1,0 +1,12 @@
+package io.dekorate.cli;
+
+import picocli.CommandLine.Command;
+
+@Command(name = "openshift", mixinStandardHelpOptions = true, version = "0.1", description = "Generates Openshift manifests.")
+public class OpenshiftCmd implements Runnable {
+
+  @Override
+  public void run() {
+    Generator.generate("openshift");
+  }
+}

--- a/src/main/java/io/dekorate/cli/TektonCmd.java
+++ b/src/main/java/io/dekorate/cli/TektonCmd.java
@@ -1,0 +1,12 @@
+package io.dekorate.cli;
+
+import picocli.CommandLine.Command;
+
+@Command(name = "tekton", mixinStandardHelpOptions = true, version = "0.1", description = "Generates Tekton manifests.")
+public class TektonCmd implements Runnable {
+
+  @Override
+  public void run() {
+    Generator.generate("tekton-pipeline", "tekton-pipeline-run", "tekton-task", "tekton-task-run");
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,0 @@
-# Configuration file
-# key = value


### PR DESCRIPTION
Fixes #1

This pull request introdcues 4 subcommands:
- kubernetes
- openshift
- knative
- tekton 

Each of which is responsible for generating manifests for the corresponding platform.